### PR TITLE
Tsv110 add mov-elimination support

### DIFF
--- a/llvm/lib/MCA/HardwareUnits/RegisterFile.cpp
+++ b/llvm/lib/MCA/HardwareUnits/RegisterFile.cpp
@@ -425,8 +425,9 @@ bool RegisterFile::canEliminateMove(const WriteState &WS, const ReadState &RS,
 
 bool RegisterFile::tryEliminateMoveOrSwap(MutableArrayRef<WriteState> Writes,
                                           MutableArrayRef<ReadState> Reads) {
-  if (Writes.size() != Reads.size())
-    return false;
+  // NOT necessary for AArch64 MOV is equivalent to ORR need 2 read 1 write
+  // if (Writes.size() != Reads.size())
+  //   return false;
 
   // This logic assumes that writes and reads are contributed by a register move
   // or a register swap operation. In particular, it assumes a simple register

--- a/llvm/lib/Target/AArch64/AArch64SchedTSV110.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedTSV110.td
@@ -44,7 +44,7 @@ let SchedModel = TSV110Model in {
   def TSV110UnitFLdSt : ProcResGroup<[TSV110UnitFSU1, TSV110UnitFSU2, TSV110UnitLdSt]>;
   def TSV110IntegerPRF : RegisterFile<32, [GPR64common, GPR64, GPR64arg, GPR32all], [1, 1, 1], [1, 1, 1],
                                0,  // Max moves that can be eliminated per cycle.
-                               1>; // Restrict move elimination to zero regs.
+                               0>; // Restrict move elimination to zero regs.
 
 }
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -332,11 +332,16 @@ createWinCOFFStreamer(MCContext &Ctx, std::unique_ptr<MCAsmBackend> &&TAB,
                                       IncrementalLinkerCompatible);
 }
 
-namespace {
+namespace llvm {
+namespace AArch64_MC {
 
 class AArch64MCInstrAnalysis : public MCInstrAnalysis {
 public:
   AArch64MCInstrAnalysis(const MCInstrInfo *Info) : MCInstrAnalysis(Info) {}
+
+  
+#define GET_STIPREDICATE_DECLS_FOR_MC_ANALYSIS
+#include "AArch64GenSubtargetInfo.inc"
 
   bool evaluateBranch(const MCInst &Inst, uint64_t Addr, uint64_t Size,
                       uint64_t &Target) const override {
@@ -388,10 +393,15 @@ public:
   }
 };
 
-} // end anonymous namespace
+#define GET_STIPREDICATE_DEFS_FOR_MC_ANALYSIS
+#include "AArch64GenSubtargetInfo.inc"
+
+} // end of namespace AArch64_MC
+
+} // end of namespace llvm
 
 static MCInstrAnalysis *createAArch64InstrAnalysis(const MCInstrInfo *Info) {
-  return new AArch64MCInstrAnalysis(Info);
+  return new AArch64_MC::AArch64MCInstrAnalysis(Info);
 }
 
 // Force static initialization.


### PR DESCRIPTION
1. 修复了子类函数的重载问题
2. 支持不是zero寄存器的mov-消除(既然这样，加入XZR，WZR的支持，好像也不是这么重要了)
